### PR TITLE
Add basic C# game server skeleton with SQLite storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -435,3 +435,7 @@ healthchecksdb
 /Assets/Plugins/NetworkLib/KojeomNet.dll.mdb
 /Assets/Plugins/NetworkLib/KojeomNet.dll.mdb.meta
 /Assets/Plugins/NetworkLib/KojeomNet.pdb.meta
+
+# Allow server project
+!GameServer/GameServer.csproj
+

--- a/GameServer/Database/DatabaseHelper.cs
+++ b/GameServer/Database/DatabaseHelper.cs
@@ -1,0 +1,89 @@
+using Microsoft.Data.Sqlite;
+using System.Collections.Generic;
+using GameServerApp.Models;
+
+namespace GameServerApp.Database
+{
+    public class DatabaseHelper
+    {
+        private readonly string _connectionString;
+
+        public DatabaseHelper(string databaseFile)
+        {
+            _connectionString = new SqliteConnectionStringBuilder { DataSource = databaseFile }.ToString();
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            var cmd = connection.CreateCommand();
+            cmd.CommandText = @"
+                CREATE TABLE IF NOT EXISTS Players (
+                    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    Name TEXT NOT NULL,
+                    X REAL NOT NULL,
+                    Y REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS Maps (
+                    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    Name TEXT NOT NULL
+                );";
+            cmd.ExecuteNonQuery();
+        }
+
+        public void SavePlayer(Character player)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            var cmd = connection.CreateCommand();
+            cmd.CommandText = @"INSERT INTO Players (Name, X, Y) VALUES ($name, $x, $y);";
+            cmd.Parameters.AddWithValue("$name", player.Name);
+            cmd.Parameters.AddWithValue("$x", player.X);
+            cmd.Parameters.AddWithValue("$y", player.Y);
+            cmd.ExecuteNonQuery();
+        }
+
+        public IEnumerable<Character> GetPlayers()
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT Name, X, Y FROM Players;";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                yield return new Character(reader.GetString(0), reader.GetDouble(1), reader.GetDouble(2));
+            }
+        }
+
+        public void SaveMap(Map map)
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            var cmd = connection.CreateCommand();
+            cmd.CommandText = "INSERT INTO Maps (Name) VALUES ($name);";
+            cmd.Parameters.AddWithValue("$name", map.Name);
+            cmd.ExecuteNonQuery();
+        }
+
+        public IEnumerable<Map> GetMaps()
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT Id, Name FROM Maps;";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                yield return new Map(reader.GetInt32(0), reader.GetString(1));
+            }
+        }
+    }
+}

--- a/GameServer/GameServer.cs
+++ b/GameServer/GameServer.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Sockets;
+using System.IO;
+using System.Threading.Tasks;
+using GameServerApp.Models;
+using GameServerApp.Database;
+using GameServerApp.Handlers;
+
+namespace GameServerApp
+{
+    public class GameServer
+    {
+        private readonly TcpListener _listener;
+        private readonly DatabaseHelper _database;
+        private readonly MovementHandler _movementHandler;
+
+        public GameServer(int port = 9000, string databaseFile = "game.db")
+        {
+            _listener = new TcpListener(IPAddress.Any, port);
+            _database = new DatabaseHelper(databaseFile);
+            _movementHandler = new MovementHandler();
+        }
+
+        public async Task StartAsync()
+        {
+            _listener.Start();
+            Console.WriteLine("Server started on port {0}", ((_listener.LocalEndpoint as IPEndPoint)?.Port));
+
+            while (true)
+            {
+                var client = await _listener.AcceptTcpClientAsync();
+                _ = HandleClientAsync(client);
+            }
+        }
+
+        private async Task HandleClientAsync(TcpClient client)
+        {
+            Console.WriteLine("Client connected.");
+
+            using var stream = client.GetStream();
+            using var reader = new StreamReader(stream);
+            using var writer = new StreamWriter(stream) { AutoFlush = true };
+
+            string? name = await reader.ReadLineAsync();
+            var character = new Character(name ?? "Unknown");
+            _database.SavePlayer(character);
+            await writer.WriteLineAsync($"HELLO {character.Name}");
+
+            string? line;
+            while ((line = await reader.ReadLineAsync()) != null)
+            {
+                var parts = line.Split(' ');
+                if (parts[0] == "MOVE" && parts.Length == 3 &&
+                    double.TryParse(parts[1], out double dx) &&
+                    double.TryParse(parts[2], out double dy))
+                {
+                    _movementHandler.Move(character, dx, dy, _database);
+                    await writer.WriteLineAsync($"POS {character.X} {character.Y}");
+                }
+            }
+        }
+    }
+}

--- a/GameServer/GameServer.csproj
+++ b/GameServer/GameServer.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/GameServer/Handlers/MovementHandler.cs
+++ b/GameServer/Handlers/MovementHandler.cs
@@ -1,0 +1,15 @@
+using GameServerApp.Models;
+using GameServerApp.Database;
+
+namespace GameServerApp.Handlers
+{
+    public class MovementHandler
+    {
+        public void Move(Character character, double dx, double dy, DatabaseHelper database)
+        {
+            character.X += dx;
+            character.Y += dy;
+            database.SavePlayer(character);
+        }
+    }
+}

--- a/GameServer/Models/Character.cs
+++ b/GameServer/Models/Character.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace GameServerApp.Models
+{
+    public class Character
+    {
+        public string Name { get; }
+        public double X { get; set; }
+        public double Y { get; set; }
+        public List<Item> Inventory { get; } = new();
+
+        public Character(string name, double x = 0, double y = 0)
+        {
+            Name = name;
+            X = x;
+            Y = y;
+        }
+    }
+}

--- a/GameServer/Models/Item.cs
+++ b/GameServer/Models/Item.cs
@@ -1,0 +1,14 @@
+namespace GameServerApp.Models
+{
+    public class Item
+    {
+        public int Id { get; }
+        public string Name { get; }
+
+        public Item(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+    }
+}

--- a/GameServer/Models/Map.cs
+++ b/GameServer/Models/Map.cs
@@ -1,0 +1,14 @@
+namespace GameServerApp.Models
+{
+    public class Map
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public Map(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+    }
+}

--- a/GameServer/Program.cs
+++ b/GameServer/Program.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace GameServerApp
+{
+    public static class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            var server = new GameServer();
+            await server.StartAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement a simple TCP-based game server in C#
- add SQLite-backed database helper for players and maps
- define models for characters, items, maps and movement handling

## Testing
- `dotnet build GameServer` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ac72c449c883318d122798cf931bd1